### PR TITLE
Fix remaining Python 3 syntax errors

### DIFF
--- a/example/twisted/test.py
+++ b/example/twisted/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import random
 import time
 
@@ -40,10 +41,10 @@ class TestThread (Thread):
                     r = self.conn.search (q)
                     for rec in r:
                         self.consume (rec)
-            except zoom.Bib1Err, err:
+            except zoom.Bib1Err as err:
                 pass
-            except zoom.QuerySyntaxError, e:
-                print "e", e, "q", query_str
+            except zoom.QuerySyntaxError as e:
+                print("e", e, "q", query_str)
 
             if self.count > 500:
                 if not parse_only:
@@ -70,8 +71,8 @@ if __name__ == '__main__':
     
     end_t = time.time ()
     elapsed = end_t - start_t
-    print "total", total_count, "elapsed", elapsed
-    print "rate", total_count * 1.0 / elapsed
+    print("total", total_count, "elapsed", elapsed)
+    print("rate", total_count * 1.0 / elapsed)
     
         
         

--- a/example/twisted/textsearch.py
+++ b/example/twisted/textsearch.py
@@ -36,7 +36,7 @@ class RegExpAttribXlate (ztwist.AttribXlate):
         return re.compile (regexp)
     
     def term_xlate (self, aval, term):
-        if aval <> 1016: # USE attribute 'generic'
+        if aval != 1016: # USE attribute 'generic'
             self.raise_err (114, str (aval), self.eb)
         return "(%s)" % (term,)
     def combiner (self, operator, r1, r2):
@@ -63,7 +63,7 @@ class TextSearcher(ztwist.ErrRaiser):
         else:
             TextSearcher.real_search (*args, **kw)
     def check_match (self, line):
-        return None <> self.re_comp.search (line)
+        return None != self.re_comp.search (line)
     def translate_query (self, query, eb):
         self.re_comp = RegExpAttribXlate (eb).translate (query)
         if self.re_comp == None:

--- a/example/twisted/textsearch2.py
+++ b/example/twisted/textsearch2.py
@@ -22,9 +22,9 @@ class RegExpAttribXlate (ztwist.AttribXlate):
         lam = ztwist.AttribXlate.translate (self, query)
         return lam
     def term_xlate (self, aval, term):
-        if aval <> 1016: # USE attribute 'generic'
+        if aval != 1016: # USE attribute 'generic'
             self.raise_err (114, str (aval), self.eb)
-        return lambda s: -1 <> s.find (term)
+        return lambda s: -1 != s.find (term)
     def combiner (self, operator, r1, r2):
         if operator == 'and':
             return lambda s: (r1 (s) and r2 (s))

--- a/example/twisted/ztwist.py
+++ b/example/twisted/ztwist.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """A Z39.50 / Twisted interface. """
+from __future__ import print_function
 
 from twisted.internet import reactor, protocol
 from twisted.internet import defer
@@ -28,12 +29,12 @@ class AttribXlate(ErrRaiser):
     def translate (self, query):
         try:
             (qtyp, qval) = query
-            if qtyp <> 'type_1':
+            if qtyp != 'type_1':
                 self.raise_err (107, qtyp, self.eb)
-            if qval.attributeSet <> self.oid:
+            if qval.attributeSet != self.oid:
                 self.raise_err (123, str (qval.attributeSet), self.eb)
             return self.translate_rpn (qval.rpn)
-        except zoom.Bib1Err, e:
+        except zoom.Bib1Err as e:
             return None
     def translate_attr (self, attrs):
         """Checks attributes, and translates them to whatever the term_xlate
@@ -43,17 +44,17 @@ class AttribXlate(ErrRaiser):
         if (len (attrs) > 1 or
             (getattr (attrs[0],'attributeSet',self.oid) != self.oid)):
             self.raise_err (1024, str (attrs), self.eb)
-        if attrs [0].attributeType <> 1: # use attribute
+        if attrs [0].attributeType != 1: # use attribute
             self.raise_err (116, str (attrs), self.eb) # or 117-120
         (atyp, aval) = attrs[0].attributeValue
-        if atyp <> 'numeric':
+        if atyp != 'numeric':
             self.raise_err (113, str (attrs), self.eb)
         return aval
     def translate_term (self, term):
         """Translates term to whatever the term_xlate callback expects.
         Override this to handle term types other than 'general'."""
         (ttyp, tval) = term
-        if ttyp <> 'general':
+        if ttyp != 'general':
             self.raise_err (229, str (term), self.eb)
         return tval
         
@@ -85,13 +86,13 @@ class Z3950Server(protocol.Protocol, ErrRaiser):
     def connectionLost (self, reason):
         self.transport.loseConnection ()
         if not self.closed:
-            print "lost conn for reason", reason
+            print("lost conn for reason", reason)
     def handle_error (self, errobj):
         raise errobj
     def dataReceived (self, data):
         try:
             self.decode_ctx.feed (map (ord, data))
-        except asn1.BERError, val:
+        except asn1.BERError as val:
             self.handle_error (val)
             return
         while self.decode_ctx.val_count () > 0:
@@ -167,16 +168,16 @@ class Z3950Server(protocol.Protocol, ErrRaiser):
                 sreq.replaceIndicator == 0):
                 self.raise_err (21, sreq.resultSetName, eb)
             searcher = self.get_searcher (sreq.databaseNames, eb)
-            if searcher <> None:
+            if searcher is not None:
                 searcher.search (sreq.query, cb, eb)
-        except zoom.Bib1Err, e:
+        except zoom.Bib1Err as e:
             pass
 
 
     def get_searcher (self, dbnames, eb):
         """Override this to support multiple-db searches by creating
         an appropriate multiplexing searcher."""
-        if len (dbnames) <> 1:
+        if len (dbnames) != 1:
             self.raise_err (111, str (dbnames), eb)
             return None
         searcher = self.searcher.get (dbnames[0], None)
@@ -230,7 +231,7 @@ class Z3950Server(protocol.Protocol, ErrRaiser):
                 self.next ()
             def next (self, rec = None):
                 self.count = self.count + 1
-                if rec <> None:
+                if rec is not None:
                     self.recs.append (rec)
                 if self.count == self.rec_end:
                     self.finish ()

--- a/hacked_pydoc.py
+++ b/hacked_pydoc.py
@@ -37,7 +37,7 @@ Tommy Burnette, the original creator of manpy.
 Paul Prescod, for all his work on onlinehelp.
 Richard Chamberlain, for the first implementation of textdoc.
 
-Mynd you, møøse bites Kan be pretty nasti..."""
+Mynd you, mï¿½ï¿½se bites Kan be pretty nasti..."""
 
 # Known bugs that can't be fixed here:
 #   - imp.load_module() cannot be prevented from clobbering existing
@@ -187,7 +187,8 @@ def synopsis(filename, cache={}):
 
 class ErrorDuringImport(Exception):
     """Errors that occurred while trying to import something to document it."""
-    def __init__(self, filename, (exc, value, tb)):
+    def __init__(self, filename, exc__value__tb):
+        exc, value, tb = exc__value__tb
         self.filename = filename
         self.exc = exc
         self.value = value
@@ -277,7 +278,7 @@ class Doc:
         """Raise an exception for unimplemented types."""
         message = "don't know how to document object%s of type %s" % (
             name and ' ' + repr(name), type(object).__name__)
-        raise TypeError, message
+        raise TypeError(message)
 
     docmodule = docclass = docroutine = docother = fail
 
@@ -424,8 +425,9 @@ TT { font-family: lucidatypewriter, lucida console, courier }
         
         return '<a href="%s.html">%s</a>' % (nms[-1], object.__name__)
 
-    def modpkglink(self, (name, path, ispackage, shadowed)):
+    def modpkglink(self, name__path__ispackage__shadowed):
         """Make a link for a module or package to display in an index."""
+        name, path, ispackage, shadowed = name__path__ispackage__shadowed
         if shadowed:
             return self.grey(name)
         if path:
@@ -575,12 +577,12 @@ TT { font-family: lucidatypewriter, lucida console, courier }
                 'Package Contents', '#ffffff', '#aa55cc', contents)
         elif modules:
             contents = self.multicolumn(
-                modules, lambda (key, value), s=self: s.modulelink(value))
+                modules, lambda key__value), s=self: s.modulelink(key__value[1]))
             result = result + self.bigsection(
                 'Modules', '#fffff', '#aa55cc', contents)
 
         if classes:
-            classlist = map(lambda (key, value): value, classes)
+            classlist = map(lambda key__value: key__value[1], classes)
             contents = [
                 self.formattree(inspect.getclasstree(classlist, 1), name)]
             for key, value in classes:
@@ -1329,7 +1331,7 @@ def doc(thing, title='Python Library Documentation: %s', forceload=0):
     if type(thing) is type(''):
         try:
             object = locate(thing, forceload)
-        except ErrorDuringImport, value:
+        except ErrorDuringImport as value:
             print value
             return
         if not object:
@@ -1350,7 +1352,7 @@ def writedoc(key, forceload=0):
     """Write HTML documentation to a file in the current directory."""
     try:
         object = locate(key, forceload)
-    except ErrorDuringImport, value:
+    except ErrorDuringImport as value:
         print value
     else:
         if object:
@@ -1790,7 +1792,7 @@ def serve(port, callback=None, completer=None):
             if path and path != '.':
                 try:
                     obj = locate(path, forceload=1)
-                except ErrorDuringImport, value:
+                except ErrorDuringImport as value:
                     self.send_document(path, html.escape(str(value)))
                     return
                 if obj:
@@ -2081,7 +2083,7 @@ def cli():
                         writedoc(arg)
                 else:
                     doc(arg)
-            except ErrorDuringImport, value:
+            except ErrorDuringImport as value:
                 print value
 
     except (getopt.error, BadUsage):

--- a/tools/tbl_to_dict.py
+++ b/tools/tbl_to_dict.py
@@ -4,6 +4,7 @@ bib-1 error definitions into a Python dictionary.  Needs a tiny bit
 of by-hand postprocessing.  File ends up in bib1msg.py, which is
 part of the distribution, so you shouldn't ever need to run this.
 """
+from __future__ import print_function
 
 import htmllib
 import formatter
@@ -22,7 +23,7 @@ class MyParser(htmllib.HTMLParser):
         if len (self.lst) ==  3:
             self.strlst.append ("%s: '%s', # %s" % (self.lst [0], self.lst[1], self.lst[2]))
         else:
-            print "# Bad len lst:", str (self.lst)
+            print("# Bad len lst:", str (self.lst))
         self.lst = []
     def start_tr (self, attrs):
         self.flush () # needed
@@ -39,9 +40,9 @@ if __name__ == '__main__':
     p = MyParser (form)
     p.feed (fil.read ())
     p.close ()
-    print "bib1_msg_dict = {"
-    print ",\n".join (p.strlst)
-    print "}"
+    print("bib1_msg_dict = {")
+    print(",\n".join (p.strlst))
+    print("}")
 
     
     


### PR DESCRIPTION
https://portingguide.readthedocs.io and https://python-future.org/futurize.html

The code now passes `python3 -m flake8 --select=E999 --show-source`