### PR TITLE
handle_charset() is a method, not a function

### DIFF
--- a/PyZ3950/asn1.py
+++ b/PyZ3950/asn1.py
@@ -128,6 +128,19 @@ import copy
 import math
 
 
+def cmp(x, y):
+    """
+    Replacement for built-in function cmp that was removed in Python 3
+
+    Compare the two objects x and y and return an integer according to
+    the outcome. The return value is negative if x < y, zero if x == y
+    and strictly positive if x > y.
+    
+    https://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-function
+    """
+    return (x > y) - (x < y)
+
+
 # - elements should expose a list of possible tags, instead of just one tag,
 #    bringing CHOICE into line with other elements
 # - make test cases more comprehensive

--- a/PyZ3950/asn1.py
+++ b/PyZ3950/asn1.py
@@ -1090,7 +1090,7 @@ class OCTSTRING_class (ConditionalConstr, ELTBASE):
             ctx.len_write_known (len (val))
             ctx.bytes_write (val)
     def encode_per (self, ctx, val):
-        val = handle_charset (ctx, val)
+        val = self.handle_charset (ctx, val)
         assert (not self.extensible)
         l = len (val)
         if self.lo != None and self.lo == self.hi:


### PR DESCRIPTION
`handle_charset()` is a method defined on line 1067 and is called properly (as a method) on line 1078 and is called improperly (as a function) here.

Also, [define `cmp()`](https://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-function) for Python 3.

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./PyZ3950/asn1.py:851:16: F821 undefined name 'cmp'
        return cmp (self.tag, other.tag)
               ^
./PyZ3950/asn1.py:868:16: F821 undefined name 'cmp'
        return cmp (self.tag, other.tag)
               ^
./PyZ3950/asn1.py:928:16: F821 undefined name 'cmp'
        return cmp (self.lst, other.lst)
               ^
./PyZ3950/asn1.py:1093:15: F821 undefined name 'handle_charset'
        val = handle_charset (ctx, val)
              ^
./PyZ3950/asn1.py:1279:16: F821 undefined name 'cmp'
        return cmp ((self.top_ind, self.bits), (other.top_ind, other.bits))
               ^
```