### PR TITLE
Fix typo in variable name: indent is defined two lines above

### DIFF
--- a/compiler/foo/foo.py
+++ b/compiler/foo/foo.py
@@ -214,7 +214,7 @@ class Node:
             return child.str_depth (depth)
         indent = " " * (4 * depth)
         if hasattr (child, '__getitem__'): #XXX
-            return ident + list(map (str, child)) + "\n"
+            return indent + list(map (str, child)) + "\n"
         else:
             return indent + str (child) + "\n"
     def str_depth (self, depth): # ugh

--- a/compiler/foo/foo2.py
+++ b/compiler/foo/foo2.py
@@ -214,7 +214,7 @@ class Node:
             return child.str_depth (depth)
         indent = " " * (4 * depth)
         if hasattr (child, '__getitem__'): #XXX
-            return ident + list(map (str, child)) + "\n"
+            return indent + list(map (str, child)) + "\n"
         else:
             return indent + str (child) + "\n"
     def str_depth (self, depth): # ugh


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./compiler/foo/foo2.py:217:20: F821 undefined name 'ident'
            return ident + list(map (str, child)) + "\n"
                   ^
./compiler/foo/foo.py:217:20: F821 undefined name 'ident'
            return ident + list(map (str, child)) + "\n"
                   ^
```