### PR TITLE
Fix typo to enable server-side CCL

### DIFF
--- a/PyZ3950/zoom.py
+++ b/PyZ3950/zoom.py
@@ -456,7 +456,7 @@ Supported query types:  CCL, S-CCL, CQL, S-CQL, PQF, C2, ZSQL, CQL-TREE
                raise QuerySyntaxError (str(err))
         elif typ == 'S-CCL': # server-side ccl
             self.typ = typ
-            self.query =  ('type-2', query)
+            self.query =  ('type_2', query)
         elif typ == 'S-CQL': # server-side cql
             self.typ = typ
             xq = asn1.EXTERNAL()


### PR DESCRIPTION
Currently when a search is attempted with a query of type S-CCL, asn1.py raises an EncodingError with message "Bogus, no arm for 'type-2'". This change fixes that issue.