### PR TITLE
Fixed: Lexer can't build error when running test_library_of_congress_query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 upload.tar
 /build/
 PyZ3950/PyZ3950_parsetab.py
+launch.json

--- a/PyZ3950/ccl.py
+++ b/PyZ3950/ccl.py
@@ -57,7 +57,7 @@ t_RPAREN= r'\)'
 t_COMMA = r','
 t_SLASH = r'/'
 def t_ATTRSET(t):
-    r'(?i)ATTRSET'
+    r'(?i:(ATTRSET))'
     return t
 
 def t_SET (t): # need to def as function to override parsing as WORD, gr XXX
@@ -97,6 +97,7 @@ def t_QUAL(t):
 
 def mk_quals ():
     quals = ("|".join (['(' + x + ')' for x in list(qual_dict.keys())]))
+    print(quals)
     t_QUAL.__doc__ = "(?i)" + quals + r"|(\([0-9]+,[0-9]+\))"
 
 def t_QUOTEDVALUE(t):
@@ -111,7 +112,7 @@ word_non_init = r",|\.|\'"
 t_WORD = "(%s)(%s|%s)*" % (word_init, word_init, word_non_init)
 
 def t_LOGOP(t):
-    r'(?i)(AND)|(OR)|(NOT)'
+    r'(?i:((AND)|(OR)|(NOT)))'
     return t
 
 
@@ -352,13 +353,16 @@ def testyacc (s):
     print("RPN Query:", ast_to_rpn (ast))
 
 if __name__ == '__main__':
-    testfn = testyacc
-    #    testfn = testlex
-    testfn ('attrset (BIB1/ au="Gaiman, Neil" or ti=Sandman)')
-    while 1:
-        s = input ('Query: ')
-        if len (s) == 0:
-            break
-        testfn (s)
+    mk_quals()
+    # testfn = testyacc
+    # #    testfn = testlex
+    # testfn ('attrset (BIB1/ au="Gaiman, Neil" or ti=Sandman)')
+    # while 1:
+    #     s = input ('Query: ')
+    #     if len (s) == 0:
+    #         break
+    #     testfn (s)
+    
+    
 #    testyacc ()
 #    testlex ()

--- a/PyZ3950/ccl.py
+++ b/PyZ3950/ccl.py
@@ -97,8 +97,7 @@ def t_QUAL(t):
 
 def mk_quals ():
     quals = ("|".join (['(' + x + ')' for x in list(qual_dict.keys())]))
-    print(quals)
-    t_QUAL.__doc__ = "(?i)" + quals + r"|(\([0-9]+,[0-9]+\))"
+    t_QUAL.__doc__ = "(?i:" + quals + r"|(\([0-9]+,[0-9]+\))" + ")"
 
 def t_QUOTEDVALUE(t):
     r"(\".*?\")"
@@ -353,15 +352,14 @@ def testyacc (s):
     print("RPN Query:", ast_to_rpn (ast))
 
 if __name__ == '__main__':
-    mk_quals()
     # testfn = testyacc
-    # #    testfn = testlex
-    # testfn ('attrset (BIB1/ au="Gaiman, Neil" or ti=Sandman)')
-    # while 1:
-    #     s = input ('Query: ')
-    #     if len (s) == 0:
-    #         break
-    #     testfn (s)
+    testfn = testlex
+    testfn ('attrset (BIB1/ au="Gaiman, Neil" or ti=Sandman)')
+    while 1:
+        s = input ('Query: ')
+        if len (s) == 0:
+            break
+        testfn (s)
     
     
 #    testyacc ()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "PyZ3950"
+version = "2.04"
+description = "testing"
+
+[build-system]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core >=3.2,<4"]

--- a/tests/test_ccl.py
+++ b/tests/test_ccl.py
@@ -1,4 +1,5 @@
 import re
+import pytest
 from PyZ3950 import ccl
 
 def test_word():

--- a/tests/test_library_of_congress_query.py
+++ b/tests/test_library_of_congress_query.py
@@ -2,6 +2,8 @@
 from __future__ import print_function, absolute_import
 from PyZ3950 import zoom
 
+import pytest
+
 
 def test_library_of_congress_query():
     conn = zoom.Connection ('z3950.loc.gov', 7090)


### PR DESCRIPTION
- created a `pyproject.toml` file to resolve import statement errors
- updated regex expressions for LOGOP, ATTRSET, and QUAL tokens

Result:
passes tests test_library_of_congress_query, and test_ccl
![pyz3950_tests](https://github.com/user-attachments/assets/8c6a76fc-573a-425a-b699-bfd378ff3a7c)


