### PR TITLE
fix: make PyZ3950 compatible with Python 3.14

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,8 +4,10 @@ jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B110,B307,B311,B318,B406,B408 .
       - run: black --check . || true
@@ -18,16 +20,6 @@ jobs:
       - run: pip install -e .
       - run: mypy --install-types --non-interactive . || true
       - run: pytest .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: shopt -s globstar && pyupgrade --py39-plus **/*.py || true
       - run: safety check
-  pytest_legacy_python:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '2.7'
-      - run: pip install pytest -r requirements.txt
-      - run: pip install -e .
-      - run: pytest .
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /.tox/
 upload.tar
 /build/
+*.egg-info/
 PyZ3950/PyZ3950_parsetab.py

--- a/PyZ3950/asn1.py
+++ b/PyZ3950/asn1.py
@@ -123,7 +123,6 @@ from __future__ import print_function, absolute_import
 vers = "0.83"
 
 import array
-import string
 import copy
 import math
 
@@ -253,8 +252,8 @@ class StructBase(object):
         i = list(self.__dict__.items ())
         i.sort ()
         i = [it for it in i if it[0][0] != '_']
-        s = s + string.join ([repr (it[0]) +
-                                  ' ' + repr (it[1]) for it in i], '\n')
+        s = s + '\n'.join ([repr (it[0]) +
+                                  ' ' + repr (it[1]) for it in i])
         s = s + ']\n'
         return s
     def __eq__(self, other):
@@ -1182,7 +1181,7 @@ class CHOICE:
                 return (cname, ctyp)
         return 0
     def __repr__ (self):
-        return 'CHOICE: ' + string.join ([x[0] for x in self.choice], '\n')
+        return 'CHOICE: ' + '\n'.join ([x[0] for x in self.choice])
     # Note: we don't include types in the repr, because that can induce
     # infinite recursion.
     def encode (self, ctx, val):
@@ -1450,7 +1449,7 @@ class SEQUENCE_BASE (ELTBASE):
         return (name, typ, optional)
     def __repr__ (self):
         return  ('SEQUENCE: ' + repr (self.klass) +
-                 '\n' + string.join (list(map (repr, self.seq)), '\n'))
+                 '\n' + '\n'.join (list(map (repr, self.seq))))
     def __getitem__ (self, key):
         for e in self.seq:
             if e[0] == key:
@@ -1544,7 +1543,7 @@ class EXTERNAL_class (SEQUENCE_BASE):
     tag = (CONS_FLAG, EXTERNAL_TAG)
     def __repr__ (self):
         return  ('EXTERNAL: ' + repr (self.klass) +
-                 '\n' + string.join (list(map (repr, self.seq)), '\n'))
+                 '\n' + '\n'.join (list(map (repr, self.seq))))
     class ConsElt(SeqConsElt):
         def __init__ (self, seq, ctx):
             self.ctx = ctx

--- a/PyZ3950/ccl.py
+++ b/PyZ3950/ccl.py
@@ -22,8 +22,6 @@ a single query, but for now I don't.
 """
 
 
-import string
-
 in_setup = 0
 
 try:
@@ -57,7 +55,7 @@ t_RPAREN= r'\)'
 t_COMMA = r','
 t_SLASH = r'/'
 def t_ATTRSET(t):
-    r'(?i)ATTRSET'
+    r'(?i:ATTRSET)'
     return t
 
 def t_SET (t): # need to def as function to override parsing as WORD, gr XXX
@@ -97,7 +95,7 @@ def t_QUAL(t):
 
 def mk_quals ():
     quals = ("|".join (['(' + x + ')' for x in list(qual_dict.keys())]))
-    t_QUAL.__doc__ = "(?i)" + quals + r"|(\([0-9]+,[0-9]+\))"
+    t_QUAL.__doc__ = "(?i:" + quals + r")|(\([0-9]+,[0-9]+\))"
 
 def t_QUOTEDVALUE(t):
     r"(\".*?\")"
@@ -111,7 +109,7 @@ word_non_init = r",|\.|\'"
 t_WORD = "(%s)(%s|%s)*" % (word_init, word_init, word_non_init)
 
 def t_LOGOP(t):
-    r'(?i)(AND)|(OR)|(NOT)'
+    r'(?i:(AND)|(OR)|(NOT))'
     return t
 
 
@@ -203,7 +201,7 @@ class QuallistVal:
 def xlate_qualifier (x):
     if x[0] == '(' and x[-1] == ')':
         t = x[1:-1].split (',') # t must be of len 2 b/c of lexer
-        return (string.atoi (t[0]), string.atoi (t[1]))
+        return (int (t[0]), int (t[1]))
     return qual_dict[(x.upper ())]
 
 
@@ -266,7 +264,7 @@ def attrset_to_oid (attrset):
     if split_l[0] == '':
         split_l = oids.Z3950_ATTRS + split_l[1:]
     try:
-        intlist = list(map (string.atoi, split_l))
+        intlist = list(map (int, split_l))
     except ValueError:
         raise ParseError ('Bad OID: ' + l)
     return asn1.OidVal (intlist)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 
 pytest
-pytest-pythonpath
 pytest-cov
 tox
 

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,22 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
-from distutils.core import setup
+from setuptools import setup
 
 import vers
-import os
-import os.path
 
-# Because PLY compiles the yacc grammar to Python code, we need to run
-# that compilation at install time to avoid dropping the created files
-# in some random directory.  (Note that PLY's staleness checking
-# depends on the MD5 hash of the repr() of assorted objects, and the
-# repr is subject to change between Python versions (maybe)).
-
-# I can't find a consistent way to import modules at build time,
-# so I've removed this code for now.  (Changing directories into
-# PyZ3950 works under Python 2.2 but not 2.3, importing with pathnames
-# works under Linux but not Win 98 or XP.)
-
-
-# We define a custom build_ext
-
-from distutils.util import byte_compile
-from distutils.command.build_ext import build_ext
-from distutils.extension import Extension
-
-pyz_dir = "PyZ3950"
-
-class PLYBuild(build_ext):
-    def run(self):
-        for ext in self.extensions:
-            nm =  self.get_ext_fullname (ext.sources[0])
-#            print("running %s to generate parsing tables" % (nm,))
-#
-#            mod = __import__ (os.path.join (pyz_dir,nm))
-
-
-
-foo = Extension ("parsetab", ["ccl"])
+# PLY compiles the yacc/lex tables to Python at import time (see ccl.py),
+# so no build-time extension step is needed here.
 
 classifiers = """\
 Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 Programming Language :: Python
+Programming Language :: Python :: 3
+Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
+Programming Language :: Python :: 3.14
 Topic :: Internet :: Z39.50"""
 
 setup (name="PyZ3950",
@@ -55,9 +29,7 @@ setup (name="PyZ3950",
        """Pure Python implementation of ASN.1 and Z39.50 v3,
        with a simple MARC parser thrown in.  See the URL for details.""",
        platforms = ["any"],
-       classifiers = filter(None, classifiers.split("\n")),
+       classifiers = list(filter(None, classifiers.split("\n"))),
        url = "http://www.pobox.com/~asl2/software/PyZ3950",
        packages = ["PyZ3950"],
-       cmdclass = {'build_ext' : PLYBuild},
-       ext_modules= [foo])
-
+       python_requires = ">=3.9")

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
 envlist=
-    py27
-    py35
+    py39
+    py310
+    py311
+    py312
+    py313
+    py314
 
 [testenv]
 deps=-r requirements_dev.txt
 commands=pytest
-
-[testenv:py27]
-basepython=python2.7
-
-[testenv:py35]
-basepython=python3.5
-


### PR DESCRIPTION
The library failed to import on Python 3.11+ and broke at runtime on 3.12+. Restore compatibility and modernise the build and CI for current Python, dropping the dead Python 2 support.

- ccl.py: use scoped inline regex flags (?i:...) in the PLY token rules; Python 3.11+ rejects global flags that aren't at the start of the combined pattern
- ccl.py: replace removed string.atoi() with int()
- asn1.py: replace removed string.join(seq, sep) with sep.join(seq)
- setup.py: migrate from distutils (removed in 3.12) to setuptools, fix classifiers to a list, add python_requires and Py3 classifiers, and drop the vestigial no-op build_ext/Extension machinery
- tox.ini: target py39-py314, drop py27/py35
- CI: remove the Python 2.7 job, bump checkout/setup-python actions, pin Python 3.14, pyupgrade --py39-plus
- requirements_test.txt: drop pytest-pythonpath, which capped pytest to a version that fails on 3.14 (ast.Str removed in 3.12)
- gitignore *.egg-info/ generated by editable installs